### PR TITLE
Solving ZeroDivisionError on texts with few related sentences

### DIFF
--- a/summa/keywords.py
+++ b/summa/keywords.py
@@ -195,6 +195,10 @@ def keywords(text, ratio=0.2, words=None, language="english", split=False, score
 
     _remove_unreachable_nodes(graph)
 
+    # PageRank cannot be run in an empty graph.
+    if len(graph.nodes()) == 0:
+        return [] if split else ""
+
     # Ranks the tokens using the PageRank algorithm. Returns dict of lemma -> score
     pagerank_scores = _pagerank(graph)
 

--- a/summa/summarizer.py
+++ b/summa/summarizer.py
@@ -99,6 +99,10 @@ def summarize(text, ratio=0.2, words=None, language="english", split=False, scor
     # Remove all nodes with all edges weights equal to zero.
     _remove_unreachable_nodes(graph)
 
+    # PageRank cannot be run in an empty graph.
+    if len(graph.nodes()) == 0:
+        return [] if split else ""
+
     # Ranks the tokens using the PageRank algorithm. Returns dict of sentence -> score
     pagerank_scores = _pagerank(graph)
 

--- a/test/test_data/few_distinct_words.txt
+++ b/test/test_data/few_distinct_words.txt
@@ -1,0 +1,10 @@
+here here.
+there there.
+here here.
+there there.
+here here.
+there there.
+here here.
+there there.
+here here.
+there there.

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -18,6 +18,13 @@ class TestSummarizer(unittest.TestCase):
         kwds_lst = keywords(text, split=True)
         self.assertTrue(len(kwds_lst))
 
+    def test_keywords_few_distinct_words_is_empty_string(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEquals(keywords(text), "")
+
+    def test_keywords_few_distinct_words_split_is_empty_list(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEquals(keywords(text, split=True), [])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -17,6 +17,13 @@ class TestSummarizer(unittest.TestCase):
 
         self.assertEqual(generated_summary, summary)
 
+    def test_few_distinct_words_summarization_is_empty_string(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEquals(summarize(text), "")
+
+    def test_few_distinct_words_summarization_with_split_is_empty_list(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEquals(summarize(text, split=True), [])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2 for texts with few related sentences or keywords. See also [Gensim #387](https://github.com/RaRe-Technologies/gensim/pull/390).