### PR TITLE
Update keywords.py

### DIFF
--- a/summa/keywords.py
+++ b/summa/keywords.py
@@ -154,7 +154,7 @@ def _get_combined_keywords(_keywords, split_text):
                 if other_word in _keywords and other_word == split_text[j].decode("utf-8"):
                     combined_word.append(other_word)
                 else:
-                    for keyword in combined_word: _keywords.pop(keyword)
+                    for keyword in set(combined_word): _keywords.pop(keyword)
                     result.append(" ".join(combined_word))
                     break
     return result


### PR DESCRIPTION
This avoids a KeyError when, for whatever reason, two keywords occur right after another:

```python
from summa import keywords
keywords.keywords("Rabbit populations known to be plentiful, large, and diverse in the area. Adjacent to the site, a number number well over a thousand. The number of these rabbit populations has diminished in recent years, and perhaps we have become number to a number of their numbers numbering fewer.")
```

This results in the following for me:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "textrank/summa/keywords.py", line 212, in keywords
    combined_keywords = _get_combined_keywords(keywords, text.split())
  File "textrank/summa/summa/keywords.py", line 158, in _get_combined_keywords
    for keyword in combined_word: _keywords.pop(keyword)
KeyError: 'number'
```