### PR TITLE
Only accept str type as text parameter

### DIFF
--- a/summa/keywords.py
+++ b/summa/keywords.py
@@ -187,6 +187,9 @@ def _format_results(_keywords, combined_keywords, split, scores):
 
 
 def keywords(text, ratio=0.2, words=None, language="english", split=False, scores=False, deaccent=False):
+    if not isinstance(text, str):
+        raise ValueError("Text parameter must be a Unicode object (str)!")
+
     # Gets a dict of word -> lemma
     tokens = _clean_text_by_word(text, language, deacc=deaccent)
     split_text = list(_tokenize_by_word(text))

--- a/summa/preprocessing/textcleaner.py
+++ b/summa/preprocessing/textcleaner.py
@@ -81,24 +81,14 @@ def get_sentences(text):
 
 
 # Taken from gensim
-def to_unicode(text, encoding='utf8', errors='strict'):
-    """Convert a string (bytestring in `encoding` or unicode), to unicode."""
-    if isinstance(text, str):
-        return text
-    return str(text, encoding, errors=errors)
-
-
-# Taken from gensim
 RE_PUNCT = re.compile('([%s])+' % re.escape(string.punctuation), re.UNICODE)
 def strip_punctuation(s):
-    s = to_unicode(s)
     return RE_PUNCT.sub(" ", s)
 
 
 # Taken from gensim
 RE_NUMERIC = re.compile(r"[0-9]+", re.UNICODE)
 def strip_numeric(s):
-    s = to_unicode(s)
     return RE_NUMERIC.sub("", s)
 
 
@@ -129,12 +119,8 @@ def filter_words(sentences):
 # Taken from gensim
 def deaccent(text):
     """
-    Remove accentuation from the given string. Input text is either a unicode string or utf8
-    encoded bytestring.
+    Remove accentuation from the given string.
     """
-    if not isinstance(text, str):
-        # assume utf8 for byte strings, use default (strict) error handling
-        text = text.decode('utf8')
     norm = unicodedata.normalize("NFD", text)
     result = "".join(ch for ch in norm if unicodedata.category(ch) != 'Mn')
     return unicodedata.normalize("NFC", result)
@@ -142,13 +128,12 @@ def deaccent(text):
 
 # Taken from gensim
 PAT_ALPHABETIC = re.compile('(((?![\d])\w)+)', re.UNICODE)
-def tokenize(text, lowercase=False, deacc=False, errors="strict", to_lower=False, lower=False):
+def tokenize(text, lowercase=False, deacc=False, to_lower=False, lower=False):
     """
     Iteratively yield tokens as unicode strings, optionally also lowercasing them
     and removing accent marks.
     """
     lowercase = lowercase or to_lower or lower
-    text = to_unicode(text, errors=errors)
     if lowercase:
         text = text.lower()
     if deacc:

--- a/summa/summarizer.py
+++ b/summa/summarizer.py
@@ -110,6 +110,9 @@ def _extract_most_important_sentences(sentences, ratio, words):
 
 
 def summarize(text, ratio=0.2, words=None, language="english", split=False, scores=False):
+    if not isinstance(text, str):
+        raise ValueError("Text parameter must be a Unicode object (str)!")
+
     # Gets a list of processed sentences.
     sentences = _clean_text_by_sentences(text, language)
 

--- a/test/test_data/spanish.txt
+++ b/test/test_data/spanish.txt
@@ -1,0 +1,16 @@
+La provincia de Buenos Aires reforma el sistema educativo
+29 de septiembre de 2009
+La provincia de Buenos Aires, Argentina vuelve a implementar el año próximo el primario y el secundario tras no haber superado el sistema actual las expectativas.
+El septimo grado pasa a formar parte del secundario que durará seis años y se crearán nuevas orientaciones.
+La materia Salud y adolescencia contendrá contenidos de educación sexual y se dictará en primer año (a chicos de 12 años).
+Docentes tutores en el primero y en el último año buscarán articular adecuadamente la primaria con el secundario y este con el nivel superior (terciario o universidad).
+Se buscará que los docentes concentren su carga horaria para evitar que vayan de una escuela a otra, y que la capacitación profesional sea gratuita en sus lugares de trabajo.
+También se implementará una experiencia piloto para flexibilizar la aprobación del curso a los alumnos que adeuden dos o más materias previas.
+Pasaran de año y en contaturno cursaran las materias adeudadas.
+La implementación está siendo discutida por los directores.
+Habrá tres orientaciones: una orientada a las ciencias actuales: ciencias naturales, ciencias sociales, economía y administración, comunicación y arte, agregándose lenguas extranjeras y educación física.
+Una segunda con orientación artísitica y una tercera dedicada a la enseñanza técnica.
+También hay cambios organizativos.
+Los directores tendrán carga horaria completa y materias comunes de 1º a 6º grado para profundizar los contenidos aprendidos.
+El objetivo es minimizar la deserción, con el sistema actual la deserción es del 15,3% los primeros años y el 7,7% en los últimos.
+Se controlará las ausencias de los alumnos y los directivos decidirán las amonestaciones pero no tendrán la potestad de expulsar alumnos.

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -84,5 +84,14 @@ class TestKeywords(unittest.TestCase):
         # Verifies that there are some keywords are retrieved with accents.
         self.assertTrue(any(deaccent(keyword) != keyword for keyword in kwds))
 
+    def test_text_as_bytes_raises_exception(self):
+        # Test the keyword extraction for a text that is not a unicode object
+        # (Python 3 str).
+        text = get_text_from_test_data("spanish.txt")
+        bytes = text.encode(encoding="utf-8")
+        with self.assertRaises(ValueError):
+            keywords(bytes, language="spanish")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -1,6 +1,7 @@
 import unittest
 
 from summa.keywords import keywords
+from summa.preprocessing.textcleaner import deaccent
 from .utils import get_text_from_test_data
 
 
@@ -68,6 +69,20 @@ class TestKeywords(unittest.TestCase):
 
         kwds = keywords(text)
         self.assertTrue(len(kwds.splitlines()))
+
+    def test_spanish_without_accents(self):
+        # Test the keyword extraction with accented characters.
+        text = get_text_from_test_data("spanish.txt")
+        kwds = keywords(text, language="spanish", deaccent=True, split=True)
+        # Verifies that all words are retrieved without accents.
+        self.assertTrue(all(deaccent(keyword) == keyword for keyword in kwds))
+
+    def test_spanish_with_accents(self):
+        # Test the keyword extraction with accented characters.
+        text = get_text_from_test_data("spanish.txt")
+        kwds = keywords(text, language="spanish", deaccent=False, split=True)
+        # Verifies that there are some keywords are retrieved with accents.
+        self.assertTrue(any(deaccent(keyword) != keyword for keyword in kwds))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -98,6 +98,10 @@ class TestSummarizer(unittest.TestCase):
 
             self.assertEqual(len(selected_sentences), expected_summary_length)
 
+    def test_spanish(self):
+        # Test the summarization module with accented characters.
+        text = get_text_from_test_data("spanish.txt")
+        self.assertIsNotNone(summarize(text, language="spanish"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -103,5 +103,13 @@ class TestSummarizer(unittest.TestCase):
         text = get_text_from_test_data("spanish.txt")
         self.assertIsNotNone(summarize(text, language="spanish"))
 
+    def test_text_as_bytes_raises_exception(self):
+        # Test the keyword extraction for a text that is not a unicode object
+        # (Python 3 str).
+        text = get_text_from_test_data("spanish.txt")
+        bytes = text.encode(encoding="utf-8")
+        with self.assertRaises(ValueError):
+            summarize(bytes, language="spanish")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Only accept Python 3 Unicode type (str) as text parameter.
UTF-8 is not assumed by default, which threw an unhandled exception when it wasn't.

Merge after #23.