### PR TITLE
Added support for additional stopwords

### DIFF
--- a/summa/keywords.py
+++ b/summa/keywords.py
@@ -184,12 +184,12 @@ def _format_results(_keywords, combined_keywords, split, scores):
     return "\n".join(combined_keywords)
 
 
-def keywords(text, ratio=0.2, words=None, language="english", split=False, scores=False, deaccent=False, additional_keywords=None):
+def keywords(text, ratio=0.2, words=None, language="english", split=False, scores=False, deaccent=False, additional_stopwords=None):
     if not isinstance(text, str):
         raise ValueError("Text parameter must be a Unicode object (str)!")
 
     # Gets a dict of word -> lemma
-    tokens = _clean_text_by_word(text, language, deacc=deaccent)
+    tokens = _clean_text_by_word(text, language, deacc=deaccent, additional_stopwords=additional_stopwords)
     split_text = list(_tokenize_by_word(text))
 
     # Creates the graph and adds the edges

--- a/summa/keywords.py
+++ b/summa/keywords.py
@@ -184,7 +184,7 @@ def _format_results(_keywords, combined_keywords, split, scores):
     return "\n".join(combined_keywords)
 
 
-def keywords(text, ratio=0.2, words=None, language="english", split=False, scores=False, deaccent=False):
+def keywords(text, ratio=0.2, words=None, language="english", split=False, scores=False, deaccent=False, additional_keywords=None):
     if not isinstance(text, str):
         raise ValueError("Text parameter must be a Unicode object (str)!")
 

--- a/summa/preprocessing/textcleaner.py
+++ b/summa/preprocessing/textcleaner.py
@@ -33,8 +33,8 @@ UNDO_AB_SENIOR = re.compile("([A-Z][a-z]{1,2}\.)" + SEPARATOR + "(\w)")
 UNDO_AB_ACRONYM = re.compile("(\.[a-zA-Z]\.)" + SEPARATOR + "(\w)")
 
 
-LANGUAGES = {"danish", "dutch", "english", "finnish", "french", "german", \
-             "hungarian", "italian", "norwegian", "porter", "portuguese", \
+LANGUAGES = {"danish", "dutch", "english", "finnish", "french", "german",
+             "hungarian", "italian", "norwegian", "porter", "portuguese",
              "romanian", "russian", "spanish", "swedish"}
 STEMMER = None
 STOPWORDS = None
@@ -42,22 +42,25 @@ STOPWORDS = None
 
 def set_stemmer_language(language):
     global STEMMER
-    if not language in LANGUAGES:
+    if language not in LANGUAGES:
         raise ValueError("Valid languages are danish, dutch, english, finnish," +
-                 " french, german, hungarian, italian, norwegian, porter, portuguese," +
-                 "romanian, russian, spanish, swedish")
+                         " french, german, hungarian, italian, norwegian, porter, portuguese," +
+                         "romanian, russian, spanish, swedish")
     STEMMER = SnowballStemmer(language)
 
 
-def set_stopwords_by_language(language):
+def set_stopwords_by_language(language, additional_stopwords):
     global STOPWORDS
     words = get_stopwords_by_language(language)
+    words = words.strip()
+    if additional_stopwords:
+        words += " "+" ".join(additional_stopwords)
     STOPWORDS = frozenset(w for w in words.split() if w)
 
 
-def init_textcleanner(language):
+def init_textcleanner(language, additional_stopwords):
     set_stemmer_language(language)
-    set_stopwords_by_language(language)
+    set_stopwords_by_language(language, additional_stopwords)
 
 
 def split_sentences(text):
@@ -162,20 +165,20 @@ def merge_syntactic_units(original_units, filtered_units, tags=None):
     return units
 
 
-def clean_text_by_sentences(text, language="english"):
+def clean_text_by_sentences(text, language="english", additional_stopwords=None):
     """ Tokenizes a given text into sentences, applying filters and lemmatizing them.
     Returns a SyntacticUnit list. """
-    init_textcleanner(language)
+    init_textcleanner(language, additional_stopwords)
     original_sentences = split_sentences(text)
     filtered_sentences = filter_words(original_sentences)
 
     return merge_syntactic_units(original_sentences, filtered_sentences)
 
 
-def clean_text_by_word(text, language="english", deacc=False):
+def clean_text_by_word(text, language="english", deacc=False, additional_stopwords=None):
     """ Tokenizes a given text into words, applying filters and lemmatizing them.
     Returns a dict of word -> syntacticUnit. """
-    init_textcleanner(language)
+    init_textcleanner(language, additional_stopwords)
     text_without_acronyms = replace_with_separator(text, "", [AB_ACRONYM_LETTERS])
     original_words = list(tokenize(text_without_acronyms, lowercase=True, deacc=deacc))
     filtered_words = filter_words(original_words)

--- a/summa/summarizer.py
+++ b/summa/summarizer.py
@@ -109,12 +109,12 @@ def _extract_most_important_sentences(sentences, ratio, words):
         return _get_sentences_with_word_count(sentences, words)
 
 
-def summarize(text, ratio=0.2, words=None, language="english", split=False, scores=False):
+def summarize(text, ratio=0.2, words=None, language="english", split=False, scores=False, additional_stopwords=None):
     if not isinstance(text, str):
         raise ValueError("Text parameter must be a Unicode object (str)!")
 
     # Gets a list of processed sentences.
-    sentences = _clean_text_by_sentences(text, language)
+    sentences = _clean_text_by_sentences(text, language, additional_stopwords)
 
     # Creates the graph and calculates the similarity coefficient for every pair of nodes.
     graph = _build_graph([sentence.token for sentence in sentences])

--- a/summa/textrank.py
+++ b/summa/textrank.py
@@ -37,12 +37,12 @@ def get_arguments():
             words = int(a)
         elif o in ("-r", "--ratio"):
             ratio = float(a)
-        elif o in ("-e", "--additional_stopwords"):
+        elif o in ("-a", "--additional_stopwords"):
             if os.path.exists(a):
                 additional_stopwords = []
                 with open(a, "r") as f:
                     for linea in f:
-                        additional_stopwords.extend(linea.strip.split(','))
+                        additional_stopwords.extend(linea.strip().split(','))
             else:
                 additional_stopwords = a.split(",")
         else:
@@ -64,7 +64,7 @@ help_text = """Usage: textrank -t FILE
 \tFloat number (0,1] that defines the length of the summary. It's a proportion of the original text. Default value: 0.2.
 -w WORDS, --words=WORDS:
 \tNumber to limit the length of the summary. The length option is ignored if the word limit is set.
--e, --extra_keywords
+-a, --additional_stopwords
 \tEither a string of comma separated stopwords or a path to a file which has comma separated stopwords in every line
 -h, --help:
 \tprints this help

--- a/test/test_data/mihalcea_tarau.sw.txt
+++ b/test/test_data/mihalcea_tarau.sw.txt
@@ -1,0 +1,1 @@
+press,strong,people

--- a/test/test_data/mihalcea_tarau.swkw.txt
+++ b/test/test_data/mihalcea_tarau.swkw.txt
@@ -1,0 +1,20 @@
+hurricane
+gilbert
+coast
+storm
+saturday
+winds heavy
+weather
+flood
+flooding
+alert
+defense alerted
+pushed
+puerto
+cabral said
+north
+domingo
+south
+miles
+residents
+dominican

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -2,7 +2,7 @@ import unittest
 
 from summa.keywords import keywords
 from summa.preprocessing.textcleaner import deaccent
-from utils import get_text_from_test_data
+from .utils import get_text_from_test_data
 
 
 class TestKeywords(unittest.TestCase):

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -2,7 +2,7 @@ import unittest
 
 from summa.keywords import keywords
 from summa.preprocessing.textcleaner import deaccent
-from .utils import get_text_from_test_data
+from utils import get_text_from_test_data
 
 
 class TestKeywords(unittest.TestCase):

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -18,13 +18,45 @@ class TestKeywords(unittest.TestCase):
 
         self.assertEqual({str(x) for x in generated_keywords}, {str(x) for x in reference_keywords})
 
+    def test_text_keywords_wempty_stoplist(self):
+        text = get_text_from_test_data("mihalcea_tarau.txt")
+        additional_stoplist = []
+        generated_keywords = keywords(text, split=True, additional_stopwords=additional_stoplist)
+        reference_keywords = get_text_from_test_data("mihalcea_tarau.kw.txt").split("\n")
+        self.assertEqual({str(x) for x in generated_keywords}, {str(x) for x in reference_keywords})
+
+    def test_text_keywords_wstoplist(self):
+        text = get_text_from_test_data("mihalcea_tarau.txt")
+        additional_stoplist = get_text_from_test_data("mihalcea_tarau.sw.txt").strip().split(",")
+        generated_keywords = keywords(text, split=True, additional_stopwords=additional_stoplist)
+        reference_keywords = get_text_from_test_data("mihalcea_tarau.swkw.txt").split("\n")
+        self.assertEqual({str(x) for x in generated_keywords}, {str(x) for x in reference_keywords})
+
     def test_keywords_few_distinct_words_is_empty_string(self):
         text = get_text_from_test_data("few_distinct_words.txt")
         self.assertEqual(keywords(text), "")
 
+    def test_keywords_few_distinct_words_wempty_stoplist_is_empty_string(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEqual(keywords(text,additional_stopwords=[]), "")
+
+    def test_keywords_few_distinct_words_w_stoplist_is_empty_string(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        additional_stopwords = ["here","there"]
+        self.assertEqual(keywords(text,additional_stopwords=additional_stopwords), "")
+
     def test_keywords_few_distinct_words_split_is_empty_list(self):
         text = get_text_from_test_data("few_distinct_words.txt")
         self.assertEqual(keywords(text, split=True), [])
+
+    def test_keywords_few_distinct_words_wempty_stoplist_split_is_empty_list(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        self.assertEqual(keywords(text, split=True, additional_stopwords=[]), [])
+
+    def test_keywords_few_distinct_words_w_stoplist_split_is_empty_list(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        additional_stopwords = ["here","there"]
+        self.assertEqual(keywords(text, split=True, additional_stopwords=additional_stopwords), [])
 
     def test_text_summarization_on_short_input_text_and_split_is_not_empty_list(self):
         text = get_text_from_test_data("unrelated.txt")
@@ -53,6 +85,17 @@ class TestKeywords(unittest.TestCase):
 
         self.assertAlmostEqual(float(len(selected_docs_40)) / len(selected_docs_20), 0.4 / 0.2, places=1)
 
+    def test_keywords_ratio_wstopwords(self):
+        text = get_text_from_test_data("mihalcea_tarau.txt")
+        additional_stoplist = get_text_from_test_data("mihalcea_tarau.sw.txt").strip().split(",")
+        # Check ratio parameter is well behaved.
+        # Because length is taken on tokenized clean text we just check that
+        # ratio 40% is twice as long as ratio 20%
+        selected_docs_20 = keywords(text, ratio=0.2, split=True, additional_stopwords=additional_stoplist)
+        selected_docs_40 = keywords(text, ratio=0.4, split=True, additional_stopwords=additional_stoplist)
+
+        self.assertAlmostEqual(float(len(selected_docs_40)) / len(selected_docs_20), 0.4 / 0.2, places=1)
+
     def test_keywords_consecutive_keywords(self):
         text = "Rabbit populations known to be plentiful, large, and diverse \
                 in the area. \
@@ -66,8 +109,13 @@ class TestKeywords(unittest.TestCase):
 
     def test_repeated_keywords(self):
         text = get_text_from_test_data("repeated_keywords.txt")
-
         kwds = keywords(text)
+        self.assertTrue(len(kwds.splitlines()))
+
+    def test_repeated_keywords_wstopwords(self):
+        text = get_text_from_test_data("repeated_keywords.txt")
+        additional_stoplist = ["sage","user"]
+        kwds = keywords(text,additional_stopwords=additional_stoplist)
         self.assertTrue(len(kwds.splitlines()))
 
     def test_spanish_without_accents(self):

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -1,7 +1,7 @@
 import unittest
 
 from summa.summarizer import summarize
-from utils import get_text_from_test_data
+from .utils import get_text_from_test_data
 
 
 class TestSummarizer(unittest.TestCase):

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -1,7 +1,7 @@
 import unittest
 
 from summa.summarizer import summarize
-from .utils import get_text_from_test_data
+from utils import get_text_from_test_data
 
 
 class TestSummarizer(unittest.TestCase):

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -17,11 +17,35 @@ class TestSummarizer(unittest.TestCase):
 
         self.assertEqual(generated_summary, summary)
 
+    def test_reference_text_summarization_wstopwords(self):
+        text = get_text_from_test_data("mihalcea_tarau.txt")
+        additional_stoplist = get_text_from_test_data("mihalcea_tarau.sw.txt").strip().split(",")
+        # Makes a summary of the text.
+        generated_summary = summarize(text,additional_stopwords=additional_stoplist)
+
+        # To be compared to the method reference.
+        summary = get_text_from_test_data("mihalcea_tarau.summ.txt")
+
+        self.assertEqual(generated_summary, summary)
+
     def test_reference_text_summarization_with_split(self):
         text = get_text_from_test_data("mihalcea_tarau.txt")
 
         # Makes a summary of the text as a list.
         generated_summary = summarize(text, split=True)
+
+        # To be compared to the method reference.
+        summary = get_text_from_test_data("mihalcea_tarau.summ.txt")
+        summary = summary.split("\n")
+
+        self.assertSequenceEqual(generated_summary, summary)
+
+    def test_reference_text_summarization_wstopwords_with_split(self):
+        text = get_text_from_test_data("mihalcea_tarau.txt")
+        additional_stoplist = get_text_from_test_data("mihalcea_tarau.sw.txt").strip().split(",")
+
+        # Makes a summary of the text as a list.
+        generated_summary = summarize(text, split=True, additional_stopwords=additional_stoplist)
 
         # To be compared to the method reference.
         summary = get_text_from_test_data("mihalcea_tarau.summ.txt")
@@ -36,6 +60,16 @@ class TestSummarizer(unittest.TestCase):
     def test_few_distinct_words_summarization_with_split_is_empty_list(self):
         text = get_text_from_test_data("few_distinct_words.txt")
         self.assertEqual(summarize(text, split=True), [])
+
+    def test_few_distinct_words_summarization_wstopwords_is_empty_string(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        additional_stoplist = ["here","there"]
+        self.assertEqual(summarize(text, additional_stopwords=additional_stoplist), "")
+
+    def test_few_distinct_words_summarization_wstopwords_with_split_is_empty_list(self):
+        text = get_text_from_test_data("few_distinct_words.txt")
+        additional_stoplist = ["here","there"]
+        self.assertEqual(summarize(text, split=True, additional_stopwords=additional_stoplist), [])
 
     def test_summary_from_unrelated_sentences_is_not_empty_string(self):
         # Tests that the summarization of a text with unrelated sentences is not empty string.


### PR DESCRIPTION
The current implementation only allows for a set of predefined stopwords to be used. In some cases, domain specific stopwords might be useful, and even though users could remove them prior to calling textrank, given that common stopwords for the language are being removed internally, for the sake of consistency i added a new parameter `additional_stopwords`.
With this parameter you receive a list of tokens that are added to the stoplist. Therefore, the graph construction should be (a little) less memory intensive.