### PR TITLE
Removing "porter" as a language

### DIFF
--- a/README
+++ b/README
@@ -73,8 +73,8 @@ More examples
 - Define input text language (also available in :code:`keywords`):
 
   The available languages are danish, dutch, english, finnish, french, german,
-  hungarian, italian, norwegian, polish, porter, portuguese, romanian, russian,
-  spanish, swedish.
+  hungarian, italian, norwegian, polish, portuguese, romanian, russian,
+  spanish and swedish.
 
   >>> summarize(text, language='spanish')
 

--- a/summa/preprocessing/snowball.py
+++ b/summa/preprocessing/snowball.py
@@ -47,9 +47,7 @@ class SnowballStemmer():
 
     >>> from summa.preprocessing.snowball import SnowballStemmer
     >>> print(" ".join(SnowballStemmer.languages)) # See which languages are supported
-    danish dutch english finnish french german hungarian
-    italian norwegian porter portuguese romanian russian
-    spanish swedish
+    ...
     >>> stemmer = SnowballStemmer("german") # Choose a language
     >>> stemmer.stem("Autobahnen") # Stem a word
     'autobahn'
@@ -69,9 +67,23 @@ class SnowballStemmer():
                            language, a ValueError is raised.
     """
 
-    languages = ("danish", "dutch", "english", "finnish", "french", "german",
-                 "hungarian", "italian", "norwegian", "polish", "porter",
-                 "portuguese", "romanian", "russian", "spanish", "swedish")
+    languages = (
+        "danish",
+        "dutch",
+        "english",
+        "finnish",
+        "french",
+        "german",
+        "hungarian",
+        "italian",
+        "norwegian",
+        "polish",
+        "portuguese",
+        "romanian",
+        "russian",
+        "spanish",
+        "swedish",
+    )
 
     def __init__(self, language):
         if language not in self.languages:


### PR DESCRIPTION
When trying to preprocess some text using "porter" as a language, the program threw an exception:

```
>>> from summa.summarizer import summarize
>>> summarize(text, language='porter')
  ...
  File "/home/fede/summa/textrank/summa/preprocessing/snowball.py", line 121, in __init__
    _LanguageSpecificStemmer.__init__(self)
  File "/home/fede/summa/textrank/summa/preprocessing/snowball.py", line 96, in __init__
    language = type(self).__name__.lower()
RecursionError: maximum recursion depth exceeded while calling a Python object
```

This fixes this bug and also introduces minor style changes.