### PR TITLE
Changes to parsing of arguments. Add tests.

### DIFF
--- a/test/test_args.py
+++ b/test/test_args.py
@@ -1,14 +1,30 @@
 import unittest
 from summa.textrank import parse_args, SENTENCE, WORD, DEFAULT_RATIO
-from test.utils import silence_stderr
+from test.utils import get_test_file_path, silence_stderr
 
 
 class TestArgs(unittest.TestCase):
 
     @silence_stderr
-    def test_parse_fails_with_no_text_option(self):
+    def test_parse_fails_with_no_options(self):
         with self.assertRaises(SystemExit):
             parse_args([])
+
+    @silence_stderr
+    def test_parse_fails_with_no_text_option_summarize(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["--summarize"])
+
+    @silence_stderr
+    def test_parse_fails_with_no_text_option_keywords(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["--keywords"])
+
+    @silence_stderr
+    def test_parse_fails_if_multiple_modes_selected(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["--summarize", get_test_file_path("mihalcea_tarau.txt"),
+                        "-t", get_test_file_path("mihalcea_tarau.txt")])
 
     @silence_stderr
     def test_parse_fails_with_no_text_short(self):
@@ -20,52 +36,60 @@ class TestArgs(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parse_args(["--text"])
 
+    def test_parse_text_summarize(self):
+        args = parse_args(["--summarize", get_test_file_path("mihalcea_tarau.txt")])
+        self.assertTrue(isinstance(args.summarize, str))
+
+    def test_parse_text_keywords(self):
+        args = parse_args(["--keywords", get_test_file_path("mihalcea_tarau.txt")])
+        self.assertTrue(isinstance(args.keywords, str))
+
     def test_parse_text_short(self):
-        args = parse_args(["-t", "some_text"])
-        self.assertEqual("some_text", args.text)
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt")])
+        self.assertTrue(isinstance(args.text, str))
 
     def test_parse_text_long(self):
-        args = parse_args(["--text", "some_text"])
-        self.assertEqual("some_text", args.text)
+        args = parse_args(["--text", get_test_file_path("mihalcea_tarau.txt")])
+        self.assertTrue(isinstance(args.text, str))
 
     def test_summary_mode_is_default(self):
-        args = parse_args(["-t", "some_text"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt")])
         self.assertEqual(SENTENCE, args.summary)
 
     def test_summary_mode_can_be_overriden(self):
-        args = parse_args(["-t", "some_text", "-s", str(SENTENCE)])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-s", str(SENTENCE)])
         self.assertEqual(SENTENCE, args.summary)
 
     def test_keyword_mode(self):
-        args = parse_args(["-t", "some_text", "-s", str(WORD)])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-s", str(WORD)])
         self.assertEqual(WORD, args.summary)
 
     def test_ratio_default(self):
-        args = parse_args(["-t", "some_text"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt")])
         self.assertEqual(DEFAULT_RATIO, args.ratio)
 
     @silence_stderr
     def test_ratio_must_be_positive(self):
         with self.assertRaises(SystemExit):
-            parse_args(["-t", "some_text", "-r", "-1.0"])
+            parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-r", "-1.0"])
 
     @silence_stderr
     def test_ratio_must_be_less_than_1(self):
         with self.assertRaises(SystemExit):
-            parse_args(["-t", "some_text", "-r", "1.1"])
+            parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-r", "1.1"])
 
     def test_words_parameter_short(self):
-        args = parse_args(["-t", "some_text", "-w", "200"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-w", "200"])
         self.assertEqual(200, args.words)
 
     def test_words_parameter_long(self):
-        args = parse_args(["-t", "some_text", "--words", "200"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "--words", "200"])
         self.assertEqual(200, args.words)
 
     def test_additional_stopwords_short(self):
-        args = parse_args(["-t", "some_text", "-a", "uno dos tres catorce"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "-a", "uno dos tres catorce"])
         self.assertEqual("uno dos tres catorce", args.additional_stopwords)
 
     def test_additional_stopwords_long(self):
-        args = parse_args(["-t", "some_text", "--additional_stopwords", "uno dos tres catorce"])
+        args = parse_args(["-t", get_test_file_path("mihalcea_tarau.txt"), "--additional_stopwords", "uno dos tres catorce"])
         self.assertEqual("uno dos tres catorce", args.additional_stopwords)

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,9 +2,14 @@ import os.path
 import sys
 
 
-def get_text_from_test_data(file):
+def get_test_file_path(file):
     pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
-    with open(os.path.join(pre_path, file), mode='r', encoding="utf-8") as f:
+    return os.path.join(pre_path, file)
+
+
+def get_text_from_test_data(file):
+    file_path = get_test_file_path(file)
+    with open(file_path, mode='r', encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
The ouput of textrank -h is now:

```
usage: textrank [-h]
                (--summarize path/to/file | --keywords path/to/file | --text path/to/file)
                [--summary {0,1}] [--ratio r] [--words #words]
                [--additional_stopwords list,of,stopwords]

Extract the most relevant sentences or keywords of a given text using the
TextRank algorithm.

optional arguments:
  -h, --help            show this help message and exit
  --summarize path/to/file
                        Run textrank to summarize the input text. (default:
                        None)
  --keywords path/to/file
                        Run textrank to extract keywords from the input text.
                        (default: None)
  --text path/to/file, -t path/to/file
                        (Deprecated) Text to summarize if --summary option is
                        selected (default: None)
  --summary {0,1}, -s {0,1}
                        (Deprecated) Type of unit to summarize: sentence (0)
                        or word (1) (default: 0)
  --ratio r, -r r       Float number (0,1] that defines the length of the
                        summary. It's a proportion of the original text
                        (default: 0.2)
  --words #words, -w #words
                        Number to limit the length of the summary. The length
                        option is ignored if the word limit is set. (default:
                        None)
  --additional_stopwords list,of,stopwords, -a list,of,stopwords
                        Either a string of comma separated stopwords or a path
                        to a file which has comma separated stopwords in every
                        line (default: None)
```