### PR TITLE
Check whether prefix or suffix exist before replacing

### DIFF
--- a/summa/preprocessing/util.py
+++ b/summa/preprocessing/util.py
@@ -10,6 +10,9 @@ def suffix_replace(original, old, new):
     """
     Replaces the old suffix of the original string by a new suffix
     """
+    if not original.endswith(old):
+        print("'{}' is not found as suffix in '{}'".format(old, original))
+        return original
     return original[: -len(old)] + new
 
 
@@ -21,4 +24,7 @@ def prefix_replace(original, old, new):
     :param new: string
     :return: string
     """
+    if not original.startswith(old):
+        print("'{}' is not found as prefix in '{}'".format(old, original))
+        return original
     return new + original[len(old) :]


### PR DESCRIPTION
Added whether prefix or suffix exists before replacing. If prefix or suffix don't exist then it returns the original string as it is. 